### PR TITLE
Examples of the ZX-calculus

### DIFF
--- a/test/category/test_cat_zx.jl
+++ b/test/category/test_cat_zx.jl
@@ -1,0 +1,114 @@
+using Catlab
+using Catlab.Theories
+
+@signature ZXCategory{Ob,Hom} <: DaggerCompactCategory{Ob,Hom} begin
+    # Argument α is the phase, usually <: Real
+    zphase(A::Ob, α)::(A → A)
+    zcopy(A::Ob, α)::(A → (A⊗A))
+    zdelete(A::Ob, α)::(A → munit())
+    zmerge(A::Ob, α)::((A⊗A) → A)
+    zcreate(A::Ob, α)::(munit() → A)
+    
+    xphase(A::Ob, α)::(A → A)
+    xcopy(A::Ob, α)::(A → (A⊗A))
+    xdelete(A::Ob, α)::(A → munit())
+    xmerge(A::Ob, α)::((A⊗A) → A)
+    xcreate(A::Ob, α)::(munit() → A)
+    
+    hadamard(A::Ob)::(A → A)
+end
+
+# Convenience methods for phaseless spiders.
+zcopy(A) = zcopy(A,0)
+zdelete(A) = zdelete(A,0)
+zmerge(A) = zmerge(A,0)
+zcreate(A) = zcreate(A,0)
+
+xcopy(A) = xcopy(A,0)
+xdelete(A) = xdelete(A,0)
+xmerge(A) = xmerge(A,0)
+xcreate(A) = xcreate(A,0);
+
+@syntax ZXCalculus{ObExpr,HomExpr} ZXCategory begin
+    otimes(A::Ob, B::Ob) = associate_unit(new(A,B), munit)
+    otimes(f::Hom, g::Hom) = associate(new(f,g))
+    compose(f::Hom, g::Hom) = associate(new(f,g; strict=true))
+end
+
+using Metatheory, Metatheory.EGraphs
+@metatheory_init ()
+
+# Custom type APIs for the GATExpr
+using Metatheory.TermInterface
+TermInterface.gethead(t::ObExpr) = :call
+TermInterface.getargs(t::ObExpr) = [head(t), t.args...]
+TermInterface.gethead(t::HomExpr) = :call
+TermInterface.getargs(t::HomExpr) = [head(t), t.args...]
+
+abstract type CatType end
+struct ObType <: CatType
+    ob
+    mod
+end
+struct HomType <: CatType
+    codom
+    dom
+    mod
+end
+
+# Type information will be stored in the metadata
+function TermInterface.getmetadata(t::HomExpr)
+    return HomType(t.type_args[1], t.type_args[2], typeof(t).name.module)
+end
+TermInterface.getmetadata(t::ObExpr) = ObType(t, typeof(t).name.module)
+TermInterface.istree(t::GATExpr) = true
+TermInterface.arity(t::GATExpr) = length(getargs(t))
+
+struct CatlabAnalysis <: AbstractAnalysis end
+function EGraphs.make(an::Type{CatlabAnalysis}, g::EGraph, n::ENode{T}) where T
+    !(T <: GATExpr) && return t
+    return getmetadata(n)
+end
+EGraphs.join(an::Type{CatlabAnalysis}, from, to) = from
+EGraphs.islazy(x::Type{CatlabAnalysis}) = false
+
+function infer(t::GATExpr)
+    g = EGraph(t)
+    analyze!(g, CatlabAnalysis)
+    getdata(geteclass(g, g.root), CatlabAnalysis)
+end
+
+function EGraphs.extractnode(n::ENode{T}, extractor::Function) where {T <: ObExpr}
+    @assert n.head == :call
+    return getmetadata(n).ob
+end
+
+function EGraphs.extractnode(n::ENode{T}, extractor::Function) where {T <: HomExpr}
+    @assert n.head == :call
+    nargs = extractor.(n.args)
+    nmeta = getmetadata(n)
+    return nmeta.mod.Hom{nargs[1]}(nargs[2:end], GATExpr[nmeta.codom, nmeta.dom])
+end
+
+# function EGraphs.instantiateterm(g::EGraph, pat::PatTerm,  T::Type{H{K}}, sub::Sub, rule::Rule) where {H <: GATExpr, K}
+# # TODO
+# end
+
+t = Metatheory.@theory begin
+    compose(hadamard(A), hadamard(A)) |> 
+    begin
+        analyze!(_egraph, Main.CatlabAnalysis)
+        d = getdata(A, Main.CatlabAnalysis)
+        return d.mod.id(d.ob)
+    end
+end
+
+A = Ob(ZXCalculus.Ob, :A)
+h = hadamard(A)
+c = h ⋅ h
+G = EGraph(c)
+infer(zdelete(A)).codom == A
+
+saturate!(G, t)
+ex = extract!(G, astsize)
+ex == id(A)

--- a/test/category/test_zx.jl
+++ b/test/category/test_zx.jl
@@ -1,0 +1,88 @@
+using Metatheory
+using Metatheory.EGraphs
+using Metatheory.Library
+
+@metatheory_init ()
+
+struct ZXTerm{I, O}
+    head::Symbol
+    args::Vector{Any}
+end
+ZXTerm{I, O}(h) where {I, O} = ZXTerm{I, O}(h, Any[])
+
+Base.:(==)(t1::ZXTerm, t2::ZXTerm) = (
+    ninput(t1) == ninput(t2) && 
+    noutput(t1) == noutput(t2) &&
+    t1.head === t2.head &&
+    t1.args == t2.args
+)
+
+ninput(::Type{ZXTerm{I, O}}) where {I, O} = I
+noutput(::Type{ZXTerm{I, O}})  where {I, O} = O
+ninput(a::ZXTerm{I, O}) where {I, O} = I
+noutput(a::ZXTerm{I, O})  where {I, O} = O
+
+zspider(ninput, noutput, phase) = ZXTerm{ninput, noutput}(:Z, Any[phase])
+xspider(ninput, noutput, phase) = ZXTerm{ninput, noutput}(:X, Any[phase])
+hadamard() = ZXTerm{1, 1}(:H)
+id(n) = ZXTerm{n, n}(:I)
+
+compose(a, b, c...) = compose(compose(a, b), c...)
+function compose(a::ZXTerm, b::ZXTerm)
+    @assert noutput(a) == ninput(b)
+    return ZXTerm{ninput(a), noutput(b)}(:(⋅), [a, b])
+end
+
+otimes(a, b, c...) = otimes(otimes(a, b), c...)
+function otimes(a::ZXTerm, b::ZXTerm)
+    input_size = ninput(a) + ninput(b)
+    output_size = noutput(a) + noutput(b)
+    return ZXTerm{input_size, output_size}(:(⊗), [a, b])
+end
+
+using Metatheory.TermInterface
+TermInterface.gethead(t::ZXTerm) = :call
+TermInterface.getargs(t::ZXTerm) = [t.head, t.args...]
+TermInterface.istree(t::ZXTerm) = true
+function TermInterface.getmetadata(t::ZXTerm{I, O}) where {I, O}
+    t.head in (:X, :Z) && return (; :ninput => I, :noutput => O, :phase => t.args[])
+    return (; :ninput => I, :noutput => O)
+end
+TermInterface.arity(t::ZXTerm) = length(getargs(t))
+
+struct ZXAnalysis <: AbstractAnalysis end
+
+function EGraphs.make(an::Type{ZXAnalysis}, g::EGraph, n::ENode{T}) where T
+    sym = n.head
+    if !(T <: ZXTerm)
+        t = sym
+        return t
+    end
+
+    nmeta = getmetadata(n)
+    return nmeta
+end
+function EGraphs.join(an::Type{ZXAnalysis}, from, to)
+    if haskey(from, :ninput) && haskey(from, :noutput)
+        @assert haskey(to, :ninput) && haskey(to, :noutput)
+        @assert from.ninput == to.ninput && from.noutput == to.noutput
+        return (; :ninput => to.ninput, :noutput => to.noutput)
+    end
+    return from
+end
+EGraphs.islazy(x::Type{ZXAnalysis}) = true
+
+function infer(t::ZXTerm)
+    g = EGraph(t)
+    analyze!(g, ZXAnalysis)
+    getdata(geteclass(g, g.root), ZXAnalysis)
+end
+
+h = hadamard()
+c = compose(otimes(h, zspider(1, 1, pi)), otimes(id(1), zspider(1, 2, 0)))
+G = EGraph(c)
+
+noutput(c)
+
+analyze!(G, ZXAnalysis)
+@test infer(c).ninput == ninput(c) && infer(c).noutput == noutput(c)

--- a/test/category/test_zx_rule.jl
+++ b/test/category/test_zx_rule.jl
@@ -1,0 +1,64 @@
+include("test_zx.jl")
+
+h_cancel = @theory begin
+    H() ⋅ H() => I()
+end
+
+id_rule = @theory begin
+    Z(θ) |> begin
+        c = addexpr!(_egraph, _lhs_expr)
+        analyze!(_egraph, Main.ZXAnalysis)
+        md = getdata(c, Main.ZXAnalysis)
+        if md.ninput == md.noutput == 1 && getdata(θ, Main.ZXAnalysis) == 0
+            return Main.id(1)
+        else
+            return _lhs_expr
+        end
+    end
+    X(θ) |> begin
+        c = addexpr!(_egraph, _lhs_expr)
+        analyze!(_egraph, Main.ZXAnalysis)
+        md = getdata(c, Main.ZXAnalysis)
+        if md.ninput == md.noutput == 1 && getdata(θ, Main.ZXAnalysis) == 0
+            return Main.id(1)
+        else
+            return _lhs_expr
+        end
+    end
+end
+
+id_otimes_compose = @theory begin
+    I() ⊗ I() |> begin
+        c = addexpr!(_egraph, _lhs_expr)
+        analyze!(_egraph, Main.ZXAnalysis)
+        md = getdata(c, Main.ZXAnalysis)
+        @assert md.ninput == md.noutput
+        return Main.id(md.ninput)
+    end
+    I() ⋅ f => f
+    f ⋅ I() => f
+end
+
+ZXRules = h_cancel ∪ id_rule ∪ id_otimes_compose
+
+function EGraphs.extractnode(n::ENode{T}, extractor::Function) where {T <: ZXTerm}
+    args = []
+    @assert n.head == :call
+    I = ninput(T)
+    O = noutput(T)
+    for i in 2:length(n.args)
+        push!(args, extractor(n.args[i]))
+    end
+
+    return ZXTerm{I, O}(extractor(n.args[1]), args)
+end
+
+function EGraphs.instantiateterm(g::EGraph, pat::PatTerm,  T::Type{ZXTerm{I, O}}, sub::Sub, rule::Rule) where {I, O}
+    T(map(x -> EGraphs.instantiate(g, x, sub, rule), pat.args)...)
+end
+
+t = otimes(compose(h, h), compose(zspider(1, 1, 0), xspider(1, 1, 0)))
+G = EGraph(t)
+saturate!(G, ZXRules)
+t_ex = extract!(G, astsize)
+@test t_ex == id(2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -48,6 +48,7 @@ falseormissing(x) =
       include("cas/test_infer.jl")
       include("cas/test_cas.jl")
       include("category/test_cat.jl")
+      include("category/test_zx_rule.jl")
       
 
 


### PR DESCRIPTION
I wrote some examples of the ZX-calculus with Metatheory.jl.

Here, I defined `ZXAnalysis` for inferring the type of `ZXTerms`. 
When defining rules, I used `Main.ZXAnalysis` to access the data of eclasses. I don't think it's a good way. But I don't know other ways.