### PR TITLE
Improve pattern display.

### DIFF
--- a/src/EGraphs/eclass.jl
+++ b/src/EGraphs/eclass.jl
@@ -24,7 +24,8 @@ Base.iterate(a::EClass, state) = iterate(a.nodes, state)
 # Showing
 function Base.show(io::IO, a::EClass)
     print(io, "EClass $(a.id) (")
-    print(io, collect(a.nodes))
+    
+    print(io, "[", Base.join(a.nodes, ", "), "]")
     if a.data === nothing
         print(io, ")")
         return


### PR DESCRIPTION
Hi, the pattern expressons in MetaTheory seems to be displaying incorrectly.

This commit delegates most of the pretty-printing work to Julia Expr.

Parentheses are now correctly printed to respect operator precedence.

Example screenshot:
![image](https://user-images.githubusercontent.com/11240361/132245099-19fbd076-a226-437f-a4aa-24ea8d69172c.png)